### PR TITLE
Sprint #3052 set pyramid_tm to use explicit transaction manager

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/models/__init__.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/models/__init__.py
@@ -57,6 +57,7 @@ def includeme(config):
 
     """
     settings = config.get_settings()
+    settings['tm.manager_hook'] = 'pyramid_tm.explicit_manager'
 
     # use pyramid_tm to hook the transaction lifecycle to the request
     config.include('pyramid_tm')


### PR DESCRIPTION
Sets the manager_hook key to pyramid_tm.explicit_manager.