### PR TITLE
add pshell helpers to avoid NoTransaction errors

### DIFF
--- a/{{cookiecutter.repo_name}}/development.ini
+++ b/{{cookiecutter.repo_name}}/development.ini
@@ -18,6 +18,9 @@ sqlalchemy.url = sqlite:///%(here)s/{{ cookiecutter.repo_name }}.sqlite
 
 retry.attempts = 3
 
+[pshell]
+setup = {{ cookiecutter.repo_name }}.pshell_helpers.setup
+
 # By default, the toolbar only appears for clients from IP addresses
 # '127.0.0.1' and '::1'.
 # debugtoolbar.hosts = 127.0.0.1 ::1
@@ -60,7 +63,7 @@ handlers =
 qualname = {{ cookiecutter.repo_name }}
 
 [logger_sqlalchemy]
-level = INFO
+level = WARN
 handlers =
 qualname = sqlalchemy.engine
 # "level = INFO" logs SQL queries.

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/pshell.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/pshell.py
@@ -1,0 +1,12 @@
+from . import models
+
+def setup(env):
+    request = env['request']
+
+    # start a transaction
+    request.tm.begin()
+
+    # inject some vars into the shell builtins
+    env['tm'] = request.tm
+    env['dbsession'] = request.dbsession
+    env['models'] = models


### PR DESCRIPTION
fixes https://github.com/Pylons/pyramid-cookiecutter-alchemy/issues/41

Does anyone prefer `myapp/utils/pshell.py` or `myapp/pshell_utils.py` or something? I went lazy with the naming for now.