### PR TITLE
Add deprecation warning to post-gen hook

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -53,5 +53,11 @@ msg = dedent(
 
     Run your project.
         %(pserve_cmd)s development.ini
+        
+    %(separator)s
+    This cookiecutter has been deprecated in favor of the unified cookiecutter pyramid-cookiecutter-starter 
+    effective with the release of Pyramid 1.10.  Please use pyramid-cookiecutter-starter instead of this one: 
+    https://github.com/pylons/pyramid-cookiecutter-starter
+    %(separator)s
     """ % vars)
 print(msg)

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -57,8 +57,10 @@ msg = dedent(
     %(separator)s
     This cookiecutter has been deprecated in favor of the unified cookiecutter 
     pyramid-cookiecutter-starter effective with the release of Pyramid 1.10.  
-    Please use pyramid-cookiecutter-starter instead: 
-    https://github.com/pylons/pyramid-cookiecutter-starter
+    pyramid-cookiecutter-starter combines all features of pyramid-cookiecutter-alchemy 
+    and pyramid-cookiecutter-zodb. Please use pyramid-cookiecutter-starter 
+    (https://github.com/pylons/pyramid-cookiecutter-starter) instead of this one. 
+    This cookiecutter may not receive further updates.
     %(separator)s
     """ % vars)
 print(msg)

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -57,7 +57,7 @@ msg = dedent(
     %(separator)s
     This cookiecutter has been deprecated in favor of the unified cookiecutter 
     pyramid-cookiecutter-starter effective with the release of Pyramid 1.10.  
-    Please use pyramid-cookiecutter-starter instead of this one: 
+    Please use pyramid-cookiecutter-starter instead: 
     https://github.com/pylons/pyramid-cookiecutter-starter
     %(separator)s
     """ % vars)

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -55,8 +55,9 @@ msg = dedent(
         %(pserve_cmd)s development.ini
         
     %(separator)s
-    This cookiecutter has been deprecated in favor of the unified cookiecutter pyramid-cookiecutter-starter 
-    effective with the release of Pyramid 1.10.  Please use pyramid-cookiecutter-starter instead of this one: 
+    This cookiecutter has been deprecated in favor of the unified cookiecutter 
+    pyramid-cookiecutter-starter effective with the release of Pyramid 1.10.  
+    Please use pyramid-cookiecutter-starter instead of this one: 
     https://github.com/pylons/pyramid-cookiecutter-starter
     %(separator)s
     """ % vars)


### PR DESCRIPTION
Add a deprecation warning to match the README that as of Pyramid 1.10 pyramid-cookiecutter-alchemy has been merged with pyramid-cookiecutter-starter in the post-gen hook