### PR TITLE
Add deprecation warning to master branch

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -59,5 +59,15 @@ msg = dedent(
 
     Run your project.
         %(pserve_cmd)s development.ini
+        
+    %(separator)s
+    This cookiecutter has been deprecated in favor of the unified cookiecutter 
+    pyramid-cookiecutter-starter effective with the release of Pyramid 1.10.  
+    pyramid-cookiecutter-starter combines all features of pyramid-cookiecutter-alchemy 
+    and pyramid-cookiecutter-zodb. Please use pyramid-cookiecutter-starter 
+    (https://github.com/pylons/pyramid-cookiecutter-starter) instead of this one. 
+    This cookiecutter may not receive further updates.
+    %(separator)s
     """ % vars)
+
 print(msg)


### PR DESCRIPTION
Update the wording of the deprecation wording to match the README
(but add the link to the pyramid-cookiecutter-starter so users
could just copy / paste that into their terminal instead)

Corrected the PR to be to the correct branch (master)